### PR TITLE
Smili cpp priism

### DIFF
--- a/c++/mfista.hpp
+++ b/c++/mfista.hpp
@@ -34,7 +34,9 @@
 using namespace std;
 using namespace Eigen;
 
+#ifdef __cplusplus
 extern "C"
+#endif
 struct RESULT{
   int M;
   int N;
@@ -98,7 +100,9 @@ void d_TSV(VectorXd &dvec, int Nx, int Ny, VectorXd &xvec);
 void get_current_time(struct timespec *t);
 
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 // mfista_nufft_lib
 
 void mfista_imaging_core_nufft(double *u_dx, double *v_dy, 
@@ -119,4 +123,7 @@ void mfista_imaging_core_fft(int *u_idx, int *v_idx,
 			     int nonneg_flag, unsigned int fftw_plan_flag,
 			     int box_flag, float *cl_box,
 			     struct RESULT *mfista_result);
+
+#ifdef __cplusplus
 }
+#endif

--- a/c++/mfista.hpp
+++ b/c++/mfista.hpp
@@ -34,6 +34,7 @@
 using namespace std;
 using namespace Eigen;
 
+extern "C"
 struct RESULT{
   int M;
   int N;
@@ -96,6 +97,8 @@ void d_TSV(VectorXd &dvec, int Nx, int Ny, VectorXd &xvec);
 
 void get_current_time(struct timespec *t);
 
+
+extern "C" {
 // mfista_nufft_lib
 
 void mfista_imaging_core_nufft(double *u_dx, double *v_dy, 
@@ -116,4 +119,4 @@ void mfista_imaging_core_fft(int *u_idx, int *v_idx,
 			     int nonneg_flag, unsigned int fftw_plan_flag,
 			     int box_flag, float *cl_box,
 			     struct RESULT *mfista_result);
-
+}

--- a/c++/mfista.hpp
+++ b/c++/mfista.hpp
@@ -35,8 +35,9 @@ using namespace std;
 using namespace Eigen;
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
+
 struct RESULT{
   int M;
   int N;
@@ -59,6 +60,10 @@ struct RESULT{
   double *residual;
   double Lip_const;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 struct IO_FNAMES{
   unsigned int fft;


### PR DESCRIPTION
Add `extern "C"` to declarations that are exposed to PRIISM to avoid name mangling by C++ compiler. This enables to access the function by the same name with C-version. I've verified that I can access mfista library (created by `make libraries`) from Python layer as well as the executables (created by `make`) worked fine. But please double-check that this change doesn't affect an execution of executables.