### PR TITLE
support for older version of g++

### DIFF
--- a/c++/mfista_fft_lib.cpp
+++ b/c++/mfista_fft_lib.cpp
@@ -1,6 +1,7 @@
 #include "mfista.hpp"
 #include "mfista_memory.hpp"
 #include <iomanip>
+#include <memory>
 
 double fft_half_squareNorm(int Nx, int Ny, fftw_complex *FT_h)
 {


### PR DESCRIPTION
It turned out that, in older version of g++ (gcc 4.8), we have to include header file `memory` explicitly. 