### PR TITLE
Optimize nufft2d2

### DIFF
--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -256,7 +256,7 @@ void NUFFT2d2(int M, int Nx, int Ny, VectorXcd &Fout, VectorXd &E1,
 
   //openmp
   #ifdef _OPENMP
-    #pragma omp parallel for schedule(dynamic)
+    #pragma omp parallel for schedule(guided)
   #endif
   for(int k = 0; k < M; ++k){
 

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -256,7 +256,7 @@ void NUFFT2d2(int M, int Nx, int Ny, VectorXcd &Fout, VectorXd &E1,
 
   //openmp
   #ifdef _OPENMP
-    #pragma omp parallel for
+    #pragma omp parallel for schedule(dynamic)
   #endif
   for(int k = 0; k < M; ++k){
 


### PR DESCRIPTION
Applying `guided` schedule to the second loop in `NUFFT2d2` to balance workload among threads.  

See "Table 2.5 schedule Clause kind Values".
https://www.openmp.org/spec-html/5.0/openmpsu41.html#x64-1290002.9.2

Since the loop contains `if` block, workload for each loop could be different. Indeed, using profiling tool, I found that there was an inefficiency due to the imbalance, i.e. most of the threads were waiting for completion of a few threads that spent more time than others. The `guided` scheduling is expected to improve this kind of inefficiency. Note that I was also trying `dynamic` scheduling but it ended up with the slowdown.