### PR TITLE
Memory access optimization and more parallelization

### DIFF
--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -354,15 +354,15 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
   std::iota(index_array.begin(), index_array.end(), 0);
   std::sort(index_array.begin(), index_array.end(),
     [&](size_t a, size_t b) {
-      auto const u_a = round(u_dx[a] * Mrx / (2 * M_PI));
-      auto const u_b = round(u_dx[b] * Mrx / (2 * M_PI));
-      if (u_a == u_b) {
-        auto const v_a = round(v_dy[a] * Mry / (2 * M_PI));
-        auto const v_b = round(v_dy[b] * Mry / (2 * M_PI));
-        return v_a < v_b;
+      auto const v_a = round(v_dy[a] * Mry / (2 * M_PI));
+      auto const v_b = round(v_dy[b] * Mry / (2 * M_PI));
+      if (v_a == v_b) {
+        auto const u_a = round(u_dx[a] * Mrx / (2 * M_PI));
+        auto const u_b = round(u_dx[b] * Mrx / (2 * M_PI));
+        return u_a < u_b;
       }
       else {
-        return u_a < u_b;
+        return v_a < v_b;
       }
     }
   );

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -395,8 +395,11 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
 
   #ifdef _OPENMP
   #pragma omp parallel sections
+  #endif
   {
+    #ifdef _OPENMP
     #pragma omp section
+    #endif
     {
       std::vector<double> tmp(M);
       for (size_t i = 0; i < M; ++i) {
@@ -407,7 +410,9 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
       }
     }
 
+    #ifdef _OPENMP
     #pragma omp section
+    #endif
     {
       std::vector<double> tmp(M);
       for (size_t i = 0; i < M; ++i) {
@@ -418,7 +423,9 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
       }
     }
 
+    #ifdef _OPENMP
     #pragma omp section
+    #endif
     {
       std::vector<double> tmp(M);
       for (size_t i = 0; i < M; ++i) {
@@ -429,7 +436,9 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
       }
     }
 
+    #ifdef _OPENMP
     #pragma omp section
+    #endif
     {
       std::vector<double> tmp(M);
       for (size_t i = 0; i < M; ++i) {
@@ -440,7 +449,9 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
       }
     }
 
+    #ifdef _OPENMP
     #pragma omp section
+    #endif
     {
       std::vector<double> tmp(M);
       for (size_t i = 0; i < M; ++i) {
@@ -451,43 +462,6 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
       }
     }
   }
-  #else
-    std::vector<double> tmp(M);
-    for (size_t i = 0; i < M; ++i) {
-        tmp[i] = u_dx[i];
-    }
-    for (size_t i = 0; i < M; ++i) {
-        u_dx[i] = tmp[index_array[i]];
-    }
-
-    for (size_t i = 0; i < M; ++i) {
-        tmp[i] = v_dy[i];
-    }
-    for (size_t i = 0; i < M; ++i) {
-        v_dy[i] = tmp[index_array[i]];
-    }
-
-    for (size_t i = 0; i < M; ++i) {
-        tmp[i] = vis_r[i];
-    }
-    for (size_t i = 0; i < M; ++i) {
-        vis_r[i] = tmp[index_array[i]];
-    }
-
-    for (size_t i = 0; i < M; ++i) {
-        tmp[i] = vis_i[i];
-    }
-    for (size_t i = 0; i < M; ++i) {
-        vis_i[i] = tmp[index_array[i]];
-    }
-
-    for (size_t i = 0; i < M; ++i) {
-        tmp[i] = vis_std[i];
-    }
-    for (size_t i = 0; i < M; ++i) {
-        vis_std[i] = tmp[index_array[i]];
-    }
-  #endif
 }
 
 int mfista_L1_TSV_core_nufft(double *xout,

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -114,6 +114,11 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
 
   for(j = 0; j < MSP2; ++j) tmpcoef[j] = (double)(-MSP+1+j);
 
+  #ifdef _OPENMP
+  #pragma omp parallel
+  {
+  #pragma omp for
+  #endif
   for(k = 0; k < M; ++k){
 
     tmpx = round(u(k)*Mrx/(2*pi));
@@ -143,11 +148,17 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
     }
   }
 
+  #ifdef _OPENMP
+  #pragma omp for
+  #endif
   for(k = 0; k < M; ++k){
       if(idx_fftw( (my(k)-MSP+1),Mry) < Ny+1 || idx_fftw( (my(k)+MSP),Mry) < Ny+1) cover_o(k) = 1;
       if(idx_fftw(-(my(k)-MSP+1),Mry) < Ny+1 || idx_fftw(-(my(k)+MSP),Mry) < Ny+1) cover_c(k) = 1;
   }
 
+  #ifdef _OPENMP
+  #pragma omp for
+  #endif
   for(i = 0; i < Nx; ++i){
 
     tmpi = (double)(i-Nx/2);
@@ -159,6 +170,10 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
       E4(i*Ny + j) = coeff*exp(tmpx + tmpy);
     }
   }
+
+  #ifdef _OPENMP
+  }
+  #endif
 }
 
 complex<double> map_0(complex<double> x){return(x);}

--- a/c++/mfista_tools.cpp
+++ b/c++/mfista_tools.cpp
@@ -111,6 +111,29 @@ void d_TSV(VectorXd &dvec, int Nx, int Ny, VectorXd &xvec)
 
   dvec = VectorXd::Zero(Nx*Ny);
 
+  #ifdef _OPENMP
+  #pragma omp parallel
+  {
+  #pragma omp for
+  for(j = 0; j < Ny; j++){
+    dvec.segment(Nx*j,(Nx-1))
+      += 2*(xvec.segment(Nx*j,(Nx-1))-xvec.segment(Nx*j+1,(Nx-1)));
+    dvec.segment(Nx*j+1,(Nx-1))
+      += 2*(xvec.segment(Nx*j+1,(Nx-1))-xvec.segment(Nx*j,(Nx-1)));
+  }
+
+  #pragma omp for
+  for(j = 0; j < Ny-1; j++){
+    dvec.segment(Nx*j,Nx)
+      += 2*(xvec.segment(Nx*j,Nx)-xvec.segment(Nx*(j+1),Nx));
+  }
+  #pragma omp for
+  for(j = 0; j < Ny-1; j++){
+    dvec.segment(Nx*(j+1),Nx)
+      += 2*(xvec.segment(Nx*(j+1),Nx)-xvec.segment(Nx*j,Nx));
+  }
+  }
+  #else
   for(j = 0; j < Ny; j++){
     dvec.segment(Nx*j,(Nx-1))
       += 2*(xvec.segment(Nx*j,(Nx-1))-xvec.segment(Nx*j+1,(Nx-1)));
@@ -124,6 +147,7 @@ void d_TSV(VectorXd &dvec, int Nx, int Ny, VectorXd &xvec)
     dvec.segment(Nx*(j+1),Nx)
       += 2*(xvec.segment(Nx*(j+1),Nx)-xvec.segment(Nx*j,Nx));
   }
+  #endif
 }
 
 // utility for time measurement

--- a/c++/mfista_tools.cpp
+++ b/c++/mfista_tools.cpp
@@ -11,6 +11,19 @@
 double calc_Q_part(VectorXd &xvec1, VectorXd &xvec2,
 		   double c, VectorXd &AyAz, VectorXd &buf_vec)
 {
+  #ifdef _OPENMP
+  double term = 0;
+  #pragma omp parallel for reduction(+:term)
+  for (size_t i = 0; i < xvec1.size(); ++i)
+  {
+    double tmp = xvec1[i] - xvec2[i];
+    buf_vec[i] = tmp;
+    double term1 = tmp * AyAz[i];
+    double term2 = tmp * tmp;
+    term += - term1 + c * term2 / 2;
+  }
+  return term;
+  #else
   double term1, term2;
 
   // x1 - x2
@@ -21,9 +34,10 @@ double calc_Q_part(VectorXd &xvec1, VectorXd &xvec2,
   term2 = buf_vec.squaredNorm();
 
   return(-term1+c*term2/2);
+  #endif
 }
 
-// soft thresholding 
+// soft thresholding
 
 void soft_threshold(VectorXd &nvec, VectorXd &vec, double eta)
 {
@@ -59,7 +73,7 @@ void soft_threshold_nonneg_box(VectorXd &nvec, VectorXd &vec, double eta,
 			       int box_flag, VectorXd &box)
 {
   int i;
-  
+
   if(box_flag == 1){
     for(i = 0; i < vec.size(); i++){
       if(box(i) == 0) nvec(i) = 0;
@@ -103,7 +117,7 @@ void d_TSV(VectorXd &dvec, int Nx, int Ny, VectorXd &xvec)
     dvec.segment(Nx*j+1,(Nx-1))
       += 2*(xvec.segment(Nx*j+1,(Nx-1))-xvec.segment(Nx*j,(Nx-1)));
   }
-  
+
   for(j = 0; j < Ny-1; j++){
     dvec.segment(Nx*j,Nx)
       += 2*(xvec.segment(Nx*j,Nx)-xvec.segment(Nx*(j+1),Nx));


### PR DESCRIPTION
Two improvements:
1. optimize memory access
    * sort input data by my (v) and mx (u) with the priority of my over mx
    * transpose E2x and E2y for contiguous memory access
1. replace Eigen operation with parallel loop: the following Eigen operations are replaced with OpenMP parallel loop
    * preNUFFT
    * calc_F_part_nufft
    * calc_Q_part
    * d_TSV
    * (I also tried to parallelize TSV and dF_dx_nufft but no significant improvement in my development environment)