### PR TITLE
Optimize NUFFT2d1

### DIFF
--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -284,7 +284,7 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
 
   #ifdef _OPENMP
   #pragma omp parallel for
-  for (size_t i = 0; i < mbuf_l.rows(); ++i) {
+  for (int i = 0; i < mbuf_l.rows(); ++i) {
       mbuf_l(i, MSP2 + 2 * Ny) = mbuf_l(i, MSP2);
   }
   #else
@@ -410,7 +410,7 @@ double calc_F_part_nufft(int M, int Nx, int Ny,
   #ifdef _OPENMP
   double sqnorm = 0;
   #pragma omp parallel for reduction(+:sqnorm)
-  for (size_t i = 0; i < vis.size(); ++i) {
+  for (int i = 0; i < vis.size(); ++i) {
       auto const tmp = (vis[i] - yAx[i]) * weight[i];
       yAx[i] = tmp;
       sqnorm += (tmp.real() * tmp.real() + tmp.imag() * tmp.imag()) / 2;
@@ -470,10 +470,10 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
     #endif
     {
       std::vector<double> tmp(M);
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           tmp[i] = u_dx[i];
       }
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           u_dx[i] = tmp[index_array[i]];
       }
     }
@@ -483,10 +483,10 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
     #endif
     {
       std::vector<double> tmp(M);
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           tmp[i] = v_dy[i];
       }
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           v_dy[i] = tmp[index_array[i]];
       }
     }
@@ -496,10 +496,10 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
     #endif
     {
       std::vector<double> tmp(M);
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           tmp[i] = vis_r[i];
       }
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           vis_r[i] = tmp[index_array[i]];
       }
     }
@@ -509,10 +509,10 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
     #endif
     {
       std::vector<double> tmp(M);
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           tmp[i] = vis_i[i];
       }
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           vis_i[i] = tmp[index_array[i]];
       }
     }
@@ -522,10 +522,10 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
     #endif
     {
       std::vector<double> tmp(M);
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           tmp[i] = vis_std[i];
       }
-      for (size_t i = 0; i < M; ++i) {
+      for (int i = 0; i < M; ++i) {
           vis_std[i] = tmp[index_array[i]];
       }
     }
@@ -538,9 +538,12 @@ void configure_tile(
     VectorXi const &my, VectorXi const &cover_o, VectorXi const &cover_c,
     std::vector<int> &tile_boundary)
 {
+    assert(nthreads > 0);
+    assert(npixels > 0);
+
     // make histogram
     std::vector<unsigned long> hist(npixels, 0ul);
-    for (size_t k = 0; k < my.size(); ++k) {
+    for (int k = 0; k < my.size(); ++k) {
         int const myk = my(k);
         if (cover_o(k)) {
             int const col_from = myk + MSP + 1 + Ny;
@@ -566,7 +569,7 @@ void configure_tile(
     tile_boundary.clear();
     tile_boundary.push_back(0);
     unsigned long count = 0;
-    for (int i = 0; i < npixels && tile_boundary.size() < nthreads; ++i) {
+    for (int i = 0; i < npixels && tile_boundary.size() < (size_t)nthreads; ++i) {
         if (count > ndata) {
             tile_boundary.push_back(i);
             count = 0;

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -538,14 +538,13 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
 void configure_tile(int npixels, int nthreads, std::vector<int> &tile_boundary)
 {
     // innermost tile size and number of tiles
-    int tile_size = MSP2 / 2;
-    int const nadd_center = 8;
+    int tile_size = MSP; // MSP = MSP2 / 2;
+    int const nadd_center = nthreads / 3;
 
     // 4-thread reduction seems to be efficient for less number of cores
     if (nthreads < 12 || npixels < tile_size * nadd_center * 2 * 2) {
         return;
     }
-
 
     int const middle = npixels / 2 + npixels % 2;
     int left = middle;
@@ -563,7 +562,6 @@ void configure_tile(int npixels, int nthreads, std::vector<int> &tile_boundary)
     }
 
     // gradually increase tile size
-
     int const nadd = 2;
     while (left > 0) {
         tile_size *= 2;
@@ -585,7 +583,7 @@ void configure_tile(int npixels, int nthreads, std::vector<int> &tile_boundary)
     tile_boundary.push_back(npixels);
 
     // std::cout << "npixels = " << npixels << " nthreads = " << nthreads << std::endl;
-    // std::cout << "tile_boundary: " << std::endl;
+    // std::cout << "tile_boundary: " << tile_boundary.size() << " tiles" << std::endl;
     // char delim = '[';
     // for (auto i = tile_boundary.begin(); i != tile_boundary.end(); ++i) {
     //     std::cout << delim << " " << *i;

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -200,30 +200,31 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
   // openmp
   #ifdef _OPENMP
   constexpr int tile_size = MSP2;
-  int const nloop = mbuf_l.cols() / tile_size + mbuf_l.cols() % tile_size;
+  int const ncol_total = mbuf_l.cols();
+  int const ntile = ncol_total / tile_size + ncol_total % tile_size;
   #pragma omp parallel for schedule(guided)
-  for (int itile = 0; itile < nloop; ++itile) {
+  for (int itile = 0; itile < ntile; ++itile) {
     for (int k = 0; k < M; ++k) {
       int const myk = my(k);
       if (cover_o(k) == 1) {
         int const col_from = myk + MSP + 1 + Ny;
         int const col_to = col_from + MSP2;
         int const tile_from = tile_size * itile;
-        int const tile_to = min(tile_from + tile_size, (int)mbuf_l.cols());
+        int const tile_to = (itile != ntile - 1) ? tile_from + tile_size : ncol_total;
         if (tile_from < col_to && col_from < tile_to) {
-          int const icol = max(tile_from, col_from);
-          int const ncol = min(tile_to, col_to) - icol;
-          complex<double> v0 = E1(k)*(map_nufft(Fin(k)));
+          int const icol = (tile_from > col_from) ? tile_from : col_from;
+          int const ncol = ((tile_to < col_to) ? tile_to : col_to) - icol;
+          complex<double> v0half = 0.5 * E1(k)*(map_nufft(Fin(k)));
           int const ix = mx(k) + MSP + 1 + Nx;
           if (ncol == tile_size) {
             mbuf_l.block<MSP2, tile_size>(ix, icol) +=
-              0.5 * v0
+              v0half
               * E2x.block<MSP2, 1>(0, k)
               * E2y.block<tile_size, 1>(0, k).transpose();
           } else {
             for (int jcol = 0; jcol < ncol; ++jcol) {
               mbuf_l.block<MSP2, 1>(ix, icol + jcol) +=
-                0.5 * v0
+                v0half
                 * E2x.block<MSP2, 1>(0, k)
                 * E2y(icol - col_from + jcol, k);
             }
@@ -234,22 +235,22 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
         int const col_from = - myk + MSP + Ny;
         int const col_to = col_from + MSP2;
         int const tile_from = tile_size * itile;
-        int const tile_to = min(tile_from + tile_size, (int)mbuf_l.cols());
+        int const tile_to = (itile != ntile - 1) ? tile_from + tile_size : ncol_total;
         if (tile_from < col_to && col_from < tile_to) {
-          int const icol = max(tile_from, col_from);
-          int const ncol = min(tile_to, col_to) - icol;
-          complex<double> v0 = conj(E1(k)*(map_nufft(Fin(k))));
+          int const icol = (tile_from > col_from) ? tile_from : col_from;
+          int const ncol = ((tile_to < col_to) ? tile_to : col_to) - icol;
+          complex<double> v0half = 0.5 * conj(E1(k)*(map_nufft(Fin(k))));
           int const ix = - mx(k) + MSP + Nx;
           if (ncol == tile_size) {
             mbuf_l.block<MSP2, tile_size>(ix, icol) +=
-              0.5 * v0
+              v0half
               * E2x.block<MSP2, 1>(0, k).colwise().reverse()
               * E2y.block<tile_size, 1>(0, k).colwise().reverse().transpose();
           } else {
             int const offset = max(0, tile_from - col_from);
             for (int jcol = 0; jcol < ncol; ++jcol) {
               mbuf_l.block<MSP2, 1>(ix, icol + jcol) +=
-                0.5 * v0
+                v0half
                 * E2x.block<MSP2, 1>(0, k).colwise().reverse()
                 * E2y(MSP2 - 1 - offset - jcol, k);
             }

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -284,7 +284,14 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
     }
   }
 
+  #ifdef _OPENMP
+  #pragma omp parallel for
+  for (size_t i = 0; i < mbuf_l.rows(); ++i) {
+      mbuf_l(i, MSP2 + 2 * Ny) = mbuf_l(i, MSP2);
+  }
+  #else
   mbuf_l.block(0,MSP2+2*Ny,2*Nx+MSP4,1) = mbuf_l.block(0,MSP2,2*Nx+MSP4,1);
+  #endif
 
   //openmp
   #ifdef _OPENMP

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -200,7 +200,7 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
   if (!tile_boundary.empty()) {
     // openmp should be available
     int const ntile = tile_boundary.size() - 1;
-    #pragma omp parallel for schedule(guided)
+    #pragma omp parallel for schedule(dynamic)
     for (int itile = 0; itile < ntile; ++itile) {
       for (int k = 0; k < M; ++k) {
         int const myk = my(k);

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -535,69 +535,6 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
 }
 
 
-void configure_tile(int npixels, int nthreads, std::vector<int> &tile_boundary)
-{
-    // innermost tile size and number of tiles
-    int tile_size = MSP; // MSP = MSP2 / 2;
-    int const nadd_center = nthreads / 3;
-
-    // 4-thread reduction seems to be efficient for less number of cores
-    if (nthreads < 12 || npixels < tile_size * nadd_center * 2 * 2) {
-        return;
-    }
-
-    int const middle = npixels / 2 + npixels % 2;
-    int left = middle;
-    int right = middle;
-    int np = npixels;
-
-    // innermost tiles
-    tile_boundary.push_back(middle);
-    for (int i = 0; i < nadd_center; ++i) {
-        left -= tile_size;
-        tile_boundary.insert(tile_boundary.begin(), left);
-        right += tile_size;
-        tile_boundary.push_back(right);
-        np -= 2 * tile_size;
-    }
-
-    // gradually increase tile size
-    int const nadd = 2;
-    while (left > 0) {
-        tile_size *= 2;
-        for (int i = 0; i < nadd; ++i) {
-            left -= tile_size;
-            right += tile_size;
-            if (left - tile_size <= 0) {
-                left = 0;
-                right = npixels;
-                break;
-            } else {
-                tile_boundary.insert(tile_boundary.begin(), left);
-                tile_boundary.push_back(right);
-            }
-        }
-    }
-
-    tile_boundary.insert(tile_boundary.begin(), 0);
-    tile_boundary.push_back(npixels);
-
-    // std::cout << "npixels = " << npixels << " nthreads = " << nthreads << std::endl;
-    // std::cout << "tile_boundary: " << tile_boundary.size() << " boundaries" << std::endl;
-    // char delim = '[';
-    // for (auto i = tile_boundary.begin(); i != tile_boundary.end(); ++i) {
-    //     std::cout << delim << " " << *i;
-    //     delim = ',';
-    // }
-    // std::cout << " ]" << std::endl;
-    // std::cout << "   ";
-    // for (size_t i = 0; i < tile_boundary.size() - 1; ++i) {
-    //     std::cout << tile_boundary[i + 1] - tile_boundary[i] << "   ";
-    // }
-    // std::cout << std::endl;
-}
-
-
 void configure_tile(
     int npixels, int nthreads, int Ny,
     VectorXi const &my, VectorXi const &cover_o, VectorXi const &cover_c,
@@ -739,7 +676,6 @@ int mfista_L1_TSV_core_nufft(double *xout,
   #ifdef _OPENMP
     cout << "(OPENMP): Running in multi-thread with " <<
     omp_get_max_threads() << " threads." << endl << endl;
-    // configure_tile(mbuf_l.cols(), omp_get_max_threads(), tile_boundary);
   #endif
 
   cout << "Preparation for FFT.";
@@ -749,6 +685,7 @@ int mfista_L1_TSV_core_nufft(double *xout,
   preNUFFT(M, Nx, Ny, u, v, E1, E2x, E2y, E4, mx, my, cover_o, cover_c);
 
   #ifdef _OPENMP
+    // adaptive configuration of tiles
     configure_tile(mbuf_l.cols(), omp_get_max_threads(), Ny, my, cover_o, cover_c, tile_boundary);
   #endif
 

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -199,7 +199,7 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
 
   // openmp
   #ifdef _OPENMP
-  constexpr int tile_size = MSP2;
+  constexpr int tile_size = MSP2 * 2;
   int const ncol_total = mbuf_l.cols();
   int const ntile = ncol_total / tile_size + ncol_total % tile_size;
   #pragma omp parallel for schedule(guided)
@@ -216,11 +216,11 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
           int const ncol = ((tile_to < col_to) ? tile_to : col_to) - icol;
           complex<double> v0half = 0.5 * E1(k)*(map_nufft(Fin(k)));
           int const ix = mx(k) + MSP + 1 + Nx;
-          if (ncol == tile_size) {
-            mbuf_l.block<MSP2, tile_size>(ix, icol) +=
+          if (ncol == MSP2) {
+            mbuf_l.block<MSP2, MSP2>(ix, icol) +=
               v0half
               * E2x.block<MSP2, 1>(0, k)
-              * E2y.block<tile_size, 1>(0, k).transpose();
+              * E2y.block<MSP2, 1>(0, k).transpose();
           } else {
             for (int jcol = 0; jcol < ncol; ++jcol) {
               mbuf_l.block<MSP2, 1>(ix, icol + jcol) +=
@@ -241,11 +241,11 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
           int const ncol = ((tile_to < col_to) ? tile_to : col_to) - icol;
           complex<double> v0half = 0.5 * conj(E1(k)*(map_nufft(Fin(k))));
           int const ix = - mx(k) + MSP + Nx;
-          if (ncol == tile_size) {
-            mbuf_l.block<MSP2, tile_size>(ix, icol) +=
+          if (ncol == MSP2) {
+            mbuf_l.block<MSP2, MSP2>(ix, icol) +=
               v0half
               * E2x.block<MSP2, 1>(0, k).colwise().reverse()
-              * E2y.block<tile_size, 1>(0, k).colwise().reverse().transpose();
+              * E2y.block<MSP2, 1>(0, k).colwise().reverse().transpose();
           } else {
             int const offset = max(0, tile_from - col_from);
             for (int jcol = 0; jcol < ncol; ++jcol) {

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -91,9 +91,7 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
   VectorXd &E1, MatrixXd &E2x, MatrixXd &E2y,
   VectorXd &E4, VectorXi &mx, VectorXi &my, VectorXi &cover_o, VectorXi &cover_c)
 {
-  int i, j, k;
-  double taux, tauy, coeff, xix, xiy, Mrx, Mry, tmp3x, tmp3y,
-    tmpx, tmpy, pi, tmpi, tmpj, tmpcoef[MSP2];
+  double taux, tauy, coeff, Mrx, Mry, tmp3x, tmp3y, pi, tmpcoef[MSP2];
   VectorXi idx, idx_c;
 
   cover_o.setZero();
@@ -112,23 +110,23 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
   tmp3x = pow((pi/Mrx),2.0)/taux;
   tmp3y = pow((pi/Mry),2.0)/tauy;
 
-  for(j = 0; j < MSP2; ++j) tmpcoef[j] = (double)(-MSP+1+j);
+  for(int j = 0; j < MSP2; ++j) tmpcoef[j] = (double)(-MSP+1+j);
 
   #ifdef _OPENMP
   #pragma omp parallel
   {
   #pragma omp for
   #endif
-  for(k = 0; k < M; ++k){
+  for(int k = 0; k < M; ++k){
 
-    tmpx = round(u(k)*Mrx/(2*pi));
-    tmpy = round(v(k)*Mry/(2*pi));
+    double tmpx = round(u(k)*Mrx/(2*pi));
+    double tmpy = round(v(k)*Mry/(2*pi));
 
     mx(k) = (int)tmpx;
     my(k) = (int)tmpy;
 
-    xix = (2*pi*tmpx)/Mrx;
-    xiy = (2*pi*tmpy)/Mry;
+    double xix = (2*pi*tmpx)/Mrx;
+    double xiy = (2*pi*tmpy)/Mry;
 
     /* E1 */
 
@@ -142,7 +140,7 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
     tmpx = pi*(u(k)-xix)/(Mrx*taux);
     tmpy = pi*(v(k)-xiy)/(Mry*tauy);
 
-    for(j = 0; j < MSP2; ++j){
+    for(int j = 0; j < MSP2; ++j){
       E2x(j, k) = exp(tmpcoef[j]*tmpx-tmp3x*((double)((j-MSP+1)*(j-MSP+1))));
       E2y(j, k) = exp(tmpcoef[j]*tmpy-tmp3y*((double)((j-MSP+1)*(j-MSP+1))));
     }
@@ -151,7 +149,7 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
   #ifdef _OPENMP
   #pragma omp for
   #endif
-  for(k = 0; k < M; ++k){
+  for(int k = 0; k < M; ++k){
       if(idx_fftw( (my(k)-MSP+1),Mry) < Ny+1 || idx_fftw( (my(k)+MSP),Mry) < Ny+1) cover_o(k) = 1;
       if(idx_fftw(-(my(k)-MSP+1),Mry) < Ny+1 || idx_fftw(-(my(k)+MSP),Mry) < Ny+1) cover_c(k) = 1;
   }
@@ -159,14 +157,14 @@ void preNUFFT(int M, int Nx, int Ny, VectorXd &u, VectorXd &v,
   #ifdef _OPENMP
   #pragma omp for
   #endif
-  for(i = 0; i < Nx; ++i){
+  for(int i = 0; i < Nx; ++i){
 
-    tmpi = (double)(i-Nx/2);
-    tmpx = taux*tmpi*tmpi;
+    double tmpi = (double)(i-Nx/2);
+    double tmpx = taux*tmpi*tmpi;
 
-    for(j = 0; j< Ny; ++j){
-      tmpj = (double)(j-Nx/2);
-      tmpy = tauy*tmpj*tmpj;
+    for(int j = 0; j< Ny; ++j){
+      double tmpj = (double)(j-Nx/2);
+      double tmpy = tauy*tmpj*tmpj;
       E4(i*Ny + j) = coeff*exp(tmpx + tmpy);
     }
   }

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -199,8 +199,6 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
 
   if (!tile_boundary.empty()) {
     // openmp should be available
-    constexpr int tile_size = MSP2 * 4;
-    int const ncol_total = mbuf_l.cols();
     int const ntile = tile_boundary.size() - 1;
     #pragma omp parallel for schedule(guided)
     for (int itile = 0; itile < ntile; ++itile) {
@@ -533,8 +531,8 @@ void sort_input(int const M, int const Nx, int const Ny, double *u_dx, double *v
 void configure_tile(int npixels, int nthreads, std::vector<int> &tile_boundary)
 {
     // innermost tile size and number of tiles
-    int tile_size = MSP2;
-    int const nadd_center = 4;
+    int tile_size = MSP2 / 2;
+    int const nadd_center = 8;
 
     // 4-thread reduction seems to be efficient for less number of cores
     if (nthreads < 12 || npixels < tile_size * nadd_center * 2 * 2) {

--- a/c++/mfista_nufft_lib.cpp
+++ b/c++/mfista_nufft_lib.cpp
@@ -199,7 +199,7 @@ void NUFFT2d1(int M, int Nx, int Ny, VectorXd &Xout,
 
   // openmp
   #ifdef _OPENMP
-  constexpr int tile_size = MSP2 * 2;
+  constexpr int tile_size = MSP2 * 4;
   int const ncol_total = mbuf_l.cols();
   int const ntile = ncol_total / tile_size + ncol_total % tile_size;
   #pragma omp parallel for schedule(guided)

--- a/c++/mfista_tools.cpp
+++ b/c++/mfista_tools.cpp
@@ -14,7 +14,7 @@ double calc_Q_part(VectorXd &xvec1, VectorXd &xvec2,
   #ifdef _OPENMP
   double term = 0;
   #pragma omp parallel for reduction(+:term)
-  for (size_t i = 0; i < xvec1.size(); ++i)
+  for (int i = 0; i < xvec1.size(); ++i)
   {
     double tmp = xvec1[i] - xvec2[i];
     buf_vec[i] = tmp;


### PR DESCRIPTION
Rewriting the for-loop in NUFFT2d1 to scale with number of threads. 2D pixels are logically divided into segments (tiles) along Y-axis with equal number of threads. Boundary of segments is configured so that number of visibility data in the segment is as uniform as possible to equalize workload for each thread.